### PR TITLE
Update how we report to Google Analytics

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,7 @@
+import ReactGA from 'react-ga';
+ReactGA.initialize('UA-110716917-1');
+
+exports.onRouteUpdate = (state, page, pages) => {
+  ReactGA.pageview(state.location.pathname + state.location.search);
+  console.log(state.location.pathname)
+};

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,14 +20,6 @@ module.exports = {
         tableView: `Grid view`
       }
     },
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: "UA-110716917-1",
-        // Setting this parameter is optional
-        anonymize: false,
-      },
-    },
     `gatsby-transformer-remark`,
     `gatsby-plugin-sass`,
     `gatsby-plugin-react-helmet`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13632,6 +13632,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
     },
+    "react-ga": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.4.0.tgz",
+      "integrity": "sha512-tUQXx9vauTSI6IeoCe37rMGXSA+AxmdI993vvxKWULA70oR4ZS5P+qwjmSS4M6JGGjXviug7OGPxN/+n8sckqw==",
+      "requires": {
+        "prop-types": "15.6.0",
+        "react": "15.6.2"
+      }
+    },
     "react-helmet": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gatsby-source-filesystem": "^1.5.1",
     "gatsby-transformer-remark": "^1.7.12",
     "markdown-it": "^8.4.0",
+    "react-ga": "^2.4.0",
     "react-intl": "^2.4.0",
     "url-slug": "^2.0.0",
     "uswds": "^1.4.3"


### PR DESCRIPTION
We were using "gatsby-plugin-google-analytics" to report page views. This didn't allow us to send back search data.

Instead, we are using the `react-ga` module and sending data a bit more manually using `onRouteUpdate`.

Fixes #117 

⬇️ Example of what Google Analytics now sees including `?search=foo`:
![screen shot 2018-01-02 at 3 07 09 pm](https://user-images.githubusercontent.com/5697474/34500105-e54b8312-efce-11e7-8228-a574a7b20aa0.png)
